### PR TITLE
fix: handle CloudFormation tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const get = require('lodash.get');
 const glob = require('glob');
-const { resolve } = require('./utils/fs');
 
 const mergeTest = require('./utils/merge');
 
@@ -15,6 +14,7 @@ const {
 class Modularize {
   constructor(sls) {
     this.serverless = sls;
+    this.resolve = filename => this.serverless.utils.readFileSync(filename);
 
     this.hooks = {
       [`${PLUGIN}:info:info`]: this.printInfo.bind(this),
@@ -67,7 +67,7 @@ class Modularize {
 
   printInfo() {
     for (const file of this.files) {
-      this.log(file, '\n', JSON.stringify(resolve(file), null, 2), '\n');
+      this.log(file, '\n', JSON.stringify(this.resolve(file), null, 2), '\n');
     }
   }
 
@@ -80,7 +80,7 @@ class Modularize {
   mergeModules() {
     const subset = this.getSubset();
 
-    const mergedValues = [subset, ...this.files.map(resolve)].reduce(
+    const mergedValues = [subset, ...this.files.map(this.resolve)].reduce(
       mergeTest,
       {},
     );
@@ -95,7 +95,7 @@ class Modularize {
       const filename = match[0].slice(1, -1);
 
       Object.assign(this.serverless.service, {
-        custom: resolve(filename),
+        custom: this.resolve(filename),
       });
     }
   }


### PR DESCRIPTION
Currently, serverless-plugin-modularize fails if the included yml files have CloudFormation tags (e.g. !Ref, !GetAtt)

This Pull Request replaces the `resolve` function with serverless's `sls.utils.readFileSync`, so that the plugin can handle the same yml schemas that serverless can.